### PR TITLE
discovery: configurable `passing=[true|false]` in lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,16 +26,16 @@ discovery:
   type: consul
   consul:
     service-names: ["CONSUL_SERVICE_NAME1", "CONSUL_SERVICE_NAME2"]
+    healthy: true
     tag:  OPTIONAL_TAG_TO_FILTER_NODES
     local-ws-port:  OPTIONAL_TO_SPECIFY_LOCAL_HTTP_API_PORT_FOR_CONSUL_DEFAULT_IS_8500
-
-
 ```
 
 
 Key|Example|Description
 ---|---|---
 `discovery.consul.service-names`|`es-dc01-teamA-cluster01-data-nodes`| an array of service names those are registered in consul
+`discovery.consul.healthy`|`true`| boolean to determine if we should only discover passing/healthy services (default: true)
 `discovery.consul.tag`|`searcher`| **Optional** parameter `tag` to filter nodes registered for given service names, [read more..](https://www.consul.io/docs/agent/services.html)
 `discovery.consul.local-ws-port`|`8500`|**Optional** parameter to specify the rest web end point's port on localhost for consul. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
 

--- a/src/main/java/org/elasticsearch/discovery/consul/ConsulUnicastHostsProvider.java
+++ b/src/main/java/org/elasticsearch/discovery/consul/ConsulUnicastHostsProvider.java
@@ -71,11 +71,13 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
     public static final Setting<Integer> CONSUL_LOCALWSPORT = Setting.intSetting("discovery.consul.local-ws-port", 8500, Property.NodeScope);
     public static final Setting<List<String>> CONSUL_SERVICENAMES = Setting.listSetting("discovery.consul.service-names", emptyList(), Function.identity(), Property.NodeScope);
     public static final Setting<String> CONSUL_TAG = Setting.simpleString("discovery.consul.tag", Property.NodeScope);
+    public static final Setting<Boolean> CONSUL_HEALTHY = Setting.boolSetting("discovery.consul.healthy", true, Property.NodeScope);
 
     private final TransportService transportService;
     private final Set<String> consulServiceNames;
     private final int consulAgentLocalWebServicePort;
     private final String tag;
+    private final boolean healthy;
 
     public ConsulUnicastHostsProvider(Settings settings, TransportService transportService) {
         super(settings);
@@ -88,6 +90,7 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
 
         this.consulAgentLocalWebServicePort = CONSUL_LOCALWSPORT.get(settings);
         this.tag = CONSUL_TAG.get(settings);
+        this.healthy = CONSUL_HEALTHY.get(settings);
     }
 
     @Override
@@ -100,7 +103,7 @@ public class ConsulUnicastHostsProvider extends AbstractComponent implements Uni
         try {
             logger.debug("Starting discovery request");
             final long startTime = System.currentTimeMillis();
-            consulDiscoveryResults = new ConsulService(this.consulAgentLocalWebServicePort, this.tag).discoverHealthyNodes(this.consulServiceNames);
+            consulDiscoveryResults = new ConsulService(this.consulAgentLocalWebServicePort, this.tag, this.healthy).discoverNodes(this.consulServiceNames);
             logger.debug("Discovered {} nodes", (consulDiscoveryResults != null ? consulDiscoveryResults.size() : 0));
             logger.debug("{} ms it took for discovery request", (System.currentTimeMillis() - startTime));
         } catch (IOException ioException) {

--- a/src/main/java/org/elasticsearch/plugin/discovery/ConsulDiscoveryPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/discovery/ConsulDiscoveryPlugin.java
@@ -101,7 +101,8 @@ public class ConsulDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
         return Arrays.asList(
                 ConsulUnicastHostsProvider.CONSUL_LOCALWSPORT,
                 ConsulUnicastHostsProvider.CONSUL_SERVICENAMES,
-                ConsulUnicastHostsProvider.CONSUL_TAG
+                ConsulUnicastHostsProvider.CONSUL_TAG,
+                ConsulUnicastHostsProvider.CONSUL_HEALTHY
         );
     }
 


### PR DESCRIPTION
  To be able to ignore the health of a service during discovery this
  patch introduces a new configuration option: `healthy`.
  The default is `passing=true` which was the original behavior.

  Reason for this patch is to let Zen Discovery deal with service
  outages/unavailability instead of Consul. This prevents a bootstrapping
  issue where masters would be looking for eachother during startup and
  having no healthy services available yet.

  To ignore service health in lookup set the following in your elasticsearch.yml:
  `discovery.consul.healthy: false`