### PR TITLE
Add custom host for consul agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ discovery:
     healthy: true
     tag:  OPTIONAL_TAG_TO_FILTER_NODES
     local-ws-port:  OPTIONAL_TO_SPECIFY_LOCAL_HTTP_API_PORT_FOR_CONSUL_DEFAULT_IS_8500
+    local-ws-host:  OPTIONAL_TO_SPECIFY_LOCAL_HTTP_API_HOST_FOR_CONSUL_DEFAULT_IS_localhost
 ```
 
 
@@ -37,7 +38,8 @@ Key|Example|Description
 `discovery.consul.service-names`|`es-dc01-teamA-cluster01-data-nodes`| an array of service names those are registered in consul
 `discovery.consul.healthy`|`true`| boolean to determine if we should only discover passing/healthy services (default: true)
 `discovery.consul.tag`|`searcher`| **Optional** parameter `tag` to filter nodes registered for given service names, [read more..](https://www.consul.io/docs/agent/services.html)
-`discovery.consul.local-ws-port`|`8500`|**Optional** parameter to specify the rest web end point's port on localhost for consul. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
+`discovery.consul.local-ws-host`|`localhost`|**Optional** parameter to specify the rest web end point's host for consul. **default** value is `localhost`
+`discovery.consul.local-ws-port`|`8500`|**Optional** parameter to specify the rest web end point's port for consul. **default** value is `8500` [read more...] (https://www.consul.io/docs/agent/options.html#http_port)
 
 
 This plugin is based on https://github.com/grantr/elasticsearch-srv-discovery and

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.elasticsearch</groupId>
     <artifactId>elasticsearch-consul-discovery</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>5.5.1</version>
     <packaging>jar</packaging>
     <name>Elasticsearch Consul discovery plugin</name>
     <description>The Consul discovery plugin queries consul APIs for unicast

--- a/src/main/java/consul/service/ConsulService.java
+++ b/src/main/java/consul/service/ConsulService.java
@@ -65,7 +65,7 @@ import java.util.Optional;
 
 public final class ConsulService {
 	private static final String CONSUL_HEALTH_CHECK_API_ENDPOINT_TEMPLATE =
-			"http://%s:%d/v1/health/service/%s?%s";
+			"%s:%d/v1/health/service/%s?%s";
 
 	private final String consulAgentLocalHostname;
 	private final int consulAgentLocalWebServicePort;

--- a/src/main/java/consul/service/ConsulService.java
+++ b/src/main/java/consul/service/ConsulService.java
@@ -65,8 +65,9 @@ import java.util.Optional;
 
 public final class ConsulService {
 	private static final String CONSUL_HEALTH_CHECK_API_ENDPOINT_TEMPLATE =
-			"http://localhost:%d/v1/health/service/%s?%s";
+			"http://%s:%d/v1/health/service/%s?%s";
 
+	private final String consulAgentLocalHostname;
 	private final int consulAgentLocalWebServicePort;
 	private final String tag;
 	private final boolean healthy;
@@ -78,8 +79,9 @@ public final class ConsulService {
 	 * @param healthy    [true|false] (default: true) determines if service should be healthy
 	 *                   to be discovered
 	 */
-	public ConsulService(final int consulPort, final String tag, final boolean healthy) {
+	public ConsulService(final String consulHost, final int consulPort, final String tag, final boolean healthy) {
 		this.consulAgentLocalWebServicePort = consulPort;
+		this.consulAgentLocalHostname = ( consulHost.isEmpty() ) ? "localhost" : consulHost;
 		this.tag = tag;
 		this.healthy = healthy;
 	}
@@ -90,7 +92,7 @@ public final class ConsulService {
 	 * <p/>
 	 * It does it by making HTTP API call to
 	 * <p/>
-	 * http://localhost:${consulAgentLocalWebServicePort}/v1/health/service/${serviceName
+	 * http://${consulAgentLocalHostname}:${consulAgentLocalWebServicePort}/v1/health/service/${serviceName
 	 * }?${queryParams}
 	 * <p/>
 	 * queryParams is ?passing=true (false if discovery.consul.healthy: false) by default
@@ -134,7 +136,7 @@ public final class ConsulService {
 			queryParam.append(tag.trim());
 		}
 		return String.format(CONSUL_HEALTH_CHECK_API_ENDPOINT_TEMPLATE,
-				consulAgentLocalWebServicePort, serviceName,
+				consulAgentLocalHostname, consulAgentLocalWebServicePort, serviceName,
 				queryParam.toString());
 	}
 }

--- a/src/main/java/org/elasticsearch/plugin/discovery/ConsulDiscoveryPlugin.java
+++ b/src/main/java/org/elasticsearch/plugin/discovery/ConsulDiscoveryPlugin.java
@@ -100,6 +100,7 @@ public class ConsulDiscoveryPlugin extends Plugin implements DiscoveryPlugin {
     public List<Setting<?>> getSettings() {
         return Arrays.asList(
                 ConsulUnicastHostsProvider.CONSUL_LOCALWSPORT,
+                ConsulUnicastHostsProvider.CONSUL_LOCALWSHOST,
                 ConsulUnicastHostsProvider.CONSUL_SERVICENAMES,
                 ConsulUnicastHostsProvider.CONSUL_TAG,
                 ConsulUnicastHostsProvider.CONSUL_HEALTHY


### PR DESCRIPTION
This pull request add support for custom hosts for consul agent. Because is needed when we use this discovery with docker hosts ( like 172.17.0.1 ),  in this case the consul agent is located in docker host, and elasticsearch is located in a conteiner on network docker0.