### PR TITLE
Config Change for ES 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plugin zip archive will be under build/distributions/
 
 ```
 discovery:
-  type: consul
+  discovery.zen.hosts_provider: consul
   consul:
     service-names: ["CONSUL_SERVICE_NAME1", "CONSUL_SERVICE_NAME2"]
     healthy: true


### PR DESCRIPTION
I was trying to run this and it kept failing with this error:
"org.elasticsearch.bootstrap.StartupException:
java.lang.IllegalArgumentException: Unknown discovery type [consul]".
I started working back through the elasticsearch versions and
when I got to 5.6.7 it threw this error: "[WARN
][o.e.d.p.d.ConsulDiscoveryPlugin] Using discovery.type setting to set
hosts provider is deprecated. Set "discovery.zen.hosts_provider: consul"
instead"  Once I set that instead of discovery.type 6.2.1 started up
with this message which I used to know it loaded the plugin: "[INFO
][o.e.p.d.ConsulDiscoveryPlugin] Starting Consul discovery plugin"